### PR TITLE
PLF-85 Create contain expectation on map, array, slice, string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Developing
+
+-   Add ExpectIn supports to check if an element is in object.
+
 # V0.0.1 (Sep 02, 2022)
 
 -   Migrated from the [origin project](https://github.com/xybor/xyplatform).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It makes source code to be shorter and more readable by using inline commands.
 This package has the following features:
 
 -   Assert a condition, panic in case condition is false.
--   Expect a condition to occur and perform actions on this expectation.
+-   Expect a condition to occur and perform testing on this expectation.
 
 # Example
 

--- a/assert.go
+++ b/assert.go
@@ -122,6 +122,18 @@ func AssertErrorNot(err error, targets ...error) {
 	ExpectErrorNot(err, targets...).assert()
 }
 
+// AssertIn panics if the element is in the object which must be an array,
+// slice, string, or map.
+func AssertIn(object any, element any) {
+	ExpectIn(object, element).assert()
+}
+
+// AssertNotIn panics if the element is not in the object which must be an
+// array, slice, string, or map.
+func AssertNotIn(object any, element any) {
+	ExpectNotIn(object, element).assert()
+}
+
 // AssertTrue panics if the condition is false.
 func AssertTrue(b bool) {
 	ExpectTrue(b).assert()

--- a/assert_test.go
+++ b/assert_test.go
@@ -107,6 +107,27 @@ func TestAssertError(t *testing.T) {
 	xycond.AssertErrorNot(err, xyerror.AssertionError)
 }
 
+func TestAssertInWithMap(t *testing.T) {
+	var m = map[int]string{1: "foo", 2: "bar"}
+	xycond.AssertIn(m, 1)
+	xycond.AssertIn(m, 2)
+	xycond.AssertNotIn(m, 3)
+}
+
+func TestAssertInWithArray(t *testing.T) {
+	var a = []float64{0.1, 0.2}
+	xycond.AssertIn(a, 0.1)
+	xycond.AssertIn(a, 0.2)
+	xycond.AssertNotIn(a, 0.3)
+}
+
+func TestAssertInWithString(t *testing.T) {
+	var s = "foo bar"
+	xycond.AssertIn(s, "foo")
+	xycond.AssertIn(s, 'b')
+	xycond.AssertNotIn(s, "buzz")
+}
+
 func TestAssertTrue(t *testing.T) {
 	xycond.AssertTrue(true)
 	xycond.AssertFalse(false)

--- a/condition_test.go
+++ b/condition_test.go
@@ -122,6 +122,27 @@ func TestExpectError(t *testing.T) {
 	xycond.ExpectErrorNot(err, xyerror.AssertionError).Test(t)
 }
 
+func TestExpectInWithMap(t *testing.T) {
+	var m = map[int]string{1: "foo", 2: "bar"}
+	xycond.ExpectIn(m, 1).Test(t)
+	xycond.ExpectIn(m, 2).Test(t)
+	xycond.ExpectNotIn(m, 3).Test(t)
+}
+
+func TestExpectInWithArray(t *testing.T) {
+	var a = []float64{0.1, 0.2}
+	xycond.ExpectIn(a, 0.1).Test(t)
+	xycond.ExpectIn(a, 0.2).Test(t)
+	xycond.ExpectNotIn(a, 0.3).Test(t)
+}
+
+func TestExpectInWithString(t *testing.T) {
+	var s = "foo bar"
+	xycond.ExpectIn(s, "foo").Test(t)
+	xycond.ExpectIn(s, 'b').Test(t)
+	xycond.ExpectNotIn(s, "buzz").Test(t)
+}
+
 func TestExpectTrue(t *testing.T) {
 	xycond.ExpectTrue(true).Test(t)
 	xycond.ExpectFalse(false).Test(t)


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-85

#### Description

-   It should have one generic contain expectation on map, slice, array, and string.

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
