### PR TITLE
PLF-111 ExpectEmpty should print the object instead of length if fails

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -128,7 +128,7 @@ func ExpectEmpty(a any) Condition {
 	return Condition{
 		result:   va.Len() == 0,
 		trueMsg:  fmt.Sprintf("got an empty %s", va.Kind()),
-		falseMsg: fmt.Sprintf("got %s with %d element(s)", va.Kind(), va.Len()),
+		falseMsg: fmt.Sprintf("got a not empty %s (%v)", va.Kind(), a),
 	}
 }
 


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-111

#### Description

-   ExpectEmpty currently prints the length of object when it fails. But it is not easy to debug.

#### Changes

-   [ ] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   No test.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
