### PR TITLE
PLF-112 ExpectNil failed when called on a struct (instead of pointer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Developing
 
 -   Add ExpectIn supports to check if an element is in object.
+-   Fix bugs.
 
 # V0.0.1 (Sep 02, 2022)
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -52,6 +52,9 @@ func TestAssertNil(t *testing.T) {
 	var a = make([]int, 0)
 	xycond.AssertNotNil(a)
 	xycond.AssertNotNil(new(int))
+
+	var err error = xyerror.AssertionError.New("foo")
+	xycond.AssertNotNil(err)
 }
 
 func TestAssertEmpty(t *testing.T) {

--- a/condition.go
+++ b/condition.go
@@ -108,12 +108,24 @@ func ExpectNotZero[T number](a T) Condition {
 
 // ExpectNil returns a true Condition if the parameter is nil.
 func ExpectNil(a any) Condition {
-	var va = reflect.ValueOf(a)
-	return Condition{
-		result:   a == nil || va.IsNil(),
+	var cond = Condition{
+		result:   false,
 		trueMsg:  "got a nil value",
 		falseMsg: fmt.Sprintf("got a not-nil value: %v", a),
 	}
+
+	if a == nil {
+		cond.result = true
+	} else {
+		var va = reflect.ValueOf(a)
+		var expect = ExpectIs(a, reflect.Chan, reflect.Func, reflect.Interface,
+			reflect.Map, reflect.Pointer, reflect.Slice)
+		if expect.result && va.IsNil() {
+			cond.result = true
+		}
+	}
+
+	return cond
 }
 
 // ExpectNotNil returns a true Condition if the parameter is not nil.

--- a/condition_test.go
+++ b/condition_test.go
@@ -57,6 +57,9 @@ func TestExpectNil(t *testing.T) {
 	var a = make([]int, 0)
 	xycond.ExpectNotNil(a).Test(t)
 	xycond.ExpectNotNil(new(int)).Test(t)
+
+	var err error = xyerror.AssertionError.New("foo")
+	xycond.ExpectNotNil(err).Test(t)
 }
 
 func TestExpectEmpty(t *testing.T) {


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-112

#### Description

-   Problem: ExpectNil panics when called on a struct (instead of pointer).
- Steps to reproduce:
    ```
    var e error = xyerror.AssertionError.New("abc")
    ExpectNil(e)
    ```
#### Changes

-   [x] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
