### PR TITLE
PLF-113 Improve Panic function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Add ExpectIn supports to check if an element is in object.
 -   Fix bugs.
+-   Split Panic to f and non-f functions.
 
 # V0.0.1 (Sep 02, 2022)
 

--- a/README.md
+++ b/README.md
@@ -19,29 +19,53 @@ It makes source code to be shorter and more readable by using inline commands.
 This package has the following features:
 
 -   Assert a condition, panic in case condition is false.
--   Expect a condition to occur and perform testing on this expectation.
+-   Expect a condition to occur and perform actions on this expectation.
+-   Panic with an assertion error.
 
 # Example
+
+1.  Assert conditions
 
 ```golang
 xycond.AssertFalse(1 == 2)
 
 var x int
 xycond.AssertZero(x)
+```
 
+2.  Testing
+
+```golang
 // Test a condition with *testing.T or *testing.B.
-var t = &testing.T{}
-xycond.ExpectEmpty("").Test(t)
+func TestSomething(t *testing.T) {
+    xycond.ExpectEmpty("").Test(t)
+}
+```
 
+3.  Perform actions on expectation
+
+```golang
 // Perform actions on an expectation.
 xycond.ExpectEqual(1, 2).
-	True(func() {
-		fmt.Printf("1 == 2")
-	}).
-	False(func() {
-		fmt.Printf("1 != 2")
-	})
+    True(func() {
+        fmt.Printf("1 == 2")
+    }).
+    False(func() {
+        fmt.Printf("1 != 2")
+    })
 
 // Output:
 // 1 != 2
+```
+
+4.  Panic with formatted string
+
+```golang
+func foo() {
+    xycond.Panicf("foo %s", "bar")
+}
+
+func bar() int {
+    return xycond.Panic("buzzz").(int)
+}
 ```

--- a/condition.go
+++ b/condition.go
@@ -327,9 +327,14 @@ func ExpectFalse(b bool) Condition {
 	return ExpectTrue(b).revert()
 }
 
-// Panic panics with a formatted string.
-func Panic(msg string, a ...any) {
+// Panicf panics with a formatted string.
+func Panicf(msg string, a ...any) any {
 	panic(xyerror.AssertionError.Newf(msg, a...))
+}
+
+// Panicf panics with default formatted objects.
+func Panic(a ...any) any {
+	panic(xyerror.AssertionError.New(a...))
 }
 
 // JustPanic panics immediately.


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-113

#### Description

-   Panic was not yet split to f and non-f functions.
-   Moreover, Panic should return something because we still need to return statement after call Panic.
-   It should look like the following snippet:
    ```golang
    return xycond.Panic("").(int)
    ```
#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [ ] Documentation
-   [x] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
